### PR TITLE
fix: minor ui adjustments in settings and watermark

### DIFF
--- a/lib/components/Settings/index.tsx
+++ b/lib/components/Settings/index.tsx
@@ -56,9 +56,11 @@ const Settings: React.FC<SettingsProps> = (props: SettingsProps) => {
       setTransition(false);
 
       setTimeout(() => {
-        setTransition(true);
-
         setSection(value);
+
+        requestAnimationFrame(() => {
+          setTransition(true);
+        });
       }, 125);
 
       storage.updateItem('section', value);

--- a/lib/components/Terminal/Watermark/styles.ts
+++ b/lib/components/Terminal/Watermark/styles.ts
@@ -79,7 +79,7 @@ export const LogoName = styled.div`
 
 export const Wrapper = styled.div`
   position: absolute;
-  top: calc(50% + 3.5rem);
+  top: calc(50% + 2.5rem);
   font-size: 0.8125rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Summary
- Wrap `setTransition(true)` in `requestAnimationFrame` to fix settings section transition timing
- Adjust watermark vertical position (3.5rem → 2.5rem) for better centering