### PR TITLE
feat: add git integration in header

### DIFF
--- a/app/services/git.ts
+++ b/app/services/git.ts
@@ -1,0 +1,157 @@
+import { execFile } from 'child_process';
+import { resolve } from 'path';
+
+export interface GitInfo {
+  branch: string;
+  modified: number;
+  staged: number;
+  untracked: boolean;
+  ahead: number;
+  behind: number;
+  isGitRepo: boolean;
+}
+
+interface CacheEntry {
+  data: GitInfo;
+  timestamp: number;
+}
+
+const CACHE_TTL = 500;
+const cache = new Map<string, CacheEntry>();
+
+function execGit(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { cwd, encoding: 'utf-8' }, (error, stdout) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+  });
+}
+
+async function getBranch(cwd: string): Promise<string> {
+  return execGit(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+}
+
+interface StatusCounts {
+  modified: number;
+  staged: number;
+  untracked: boolean;
+}
+
+async function getStatus(cwd: string): Promise<StatusCounts> {
+  const output = await execGit(['status', '--porcelain'], cwd);
+
+  let modified = 0;
+  let staged = 0;
+  let untracked = false;
+
+  if (!output) {
+    return { modified, staged, untracked };
+  }
+
+  const lines = output.split('\n');
+
+  for (const line of lines) {
+    if (line.length < 2) continue;
+
+    const indexStatus = line[0];
+    const workTreeStatus = line[1];
+
+    // Untracked files
+    if (indexStatus === '?' && workTreeStatus === '?') {
+      untracked = true;
+      continue;
+    }
+
+    // Staged changes (index has modifications)
+    if (indexStatus !== ' ' && indexStatus !== '?') {
+      staged++;
+    }
+
+    // Unstaged modifications in working tree
+    if (workTreeStatus !== ' ' && workTreeStatus !== '?') {
+      modified++;
+    }
+  }
+
+  return { modified, staged, untracked };
+}
+
+interface AheadBehind {
+  ahead: number;
+  behind: number;
+}
+
+async function getAheadBehind(cwd: string): Promise<AheadBehind> {
+  try {
+    const output = await execGit(
+      ['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'],
+      cwd,
+    );
+
+    const parts = output.split(/\s+/);
+
+    if (parts.length >= 2) {
+      return {
+        ahead: parseInt(parts[0], 10) || 0,
+        behind: parseInt(parts[1], 10) || 0,
+      };
+    }
+
+    return { ahead: 0, behind: 0 };
+  } catch {
+    // No upstream configured or other error
+    return { ahead: 0, behind: 0 };
+  }
+}
+
+export async function getGitInfo(cwd: string): Promise<GitInfo | null> {
+  const resolvedCwd = resolve(cwd);
+
+  // Check cache
+  const cached = cache.get(resolvedCwd);
+
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    return cached.data;
+  }
+
+  try {
+    const [branch, status, aheadBehind] = await Promise.all([
+      getBranch(resolvedCwd),
+      getStatus(resolvedCwd),
+      getAheadBehind(resolvedCwd),
+    ]);
+
+    const info: GitInfo = {
+      branch,
+      modified: status.modified,
+      staged: status.staged,
+      untracked: status.untracked,
+      ahead: aheadBehind.ahead,
+      behind: aheadBehind.behind,
+      isGitRepo: true,
+    };
+
+    // Update cache
+    cache.set(resolvedCwd, {
+      data: info,
+      timestamp: Date.now(),
+    });
+
+    return info;
+  } catch {
+    // Not a git repo or git not installed
+    return null;
+  }
+}
+
+export function clearGitCache(cwd?: string): void {
+  if (cwd) {
+    cache.delete(resolve(cwd));
+  } else {
+    cache.clear();
+  }
+}

--- a/lib/components/Header/GitStatus/index.tsx
+++ b/lib/components/Header/GitStatus/index.tsx
@@ -1,0 +1,103 @@
+import { memo } from 'preact/compat';
+import styles from './styles.module.css';
+
+interface GitStatusProps {
+  gitInfo: {
+    branch: string;
+    modified: number;
+    staged: number;
+    untracked: boolean;
+    ahead: number;
+    behind: number;
+    isGitRepo: boolean;
+  } | null;
+}
+
+const BranchIcon = () => (
+  <svg
+    className={styles.branchIcon}
+    stroke="currentColor"
+    fill="currentColor"
+    strokeWidth="0"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6A2.5 2.5 0 0110 8.5H6a1 1 0 00-1 1v1.128a2.251 2.251 0 11-1.5 0V5.372a2.25 2.25 0 111.5 0v1.836A2.492 2.492 0 016 7h4a1 1 0 001-1v-.628A2.25 2.25 0 019.5 3.25zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zM3.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"
+    />
+  </svg>
+);
+
+const GitStatus: React.FC<GitStatusProps> = ({ gitInfo }) => {
+  if (!gitInfo || !gitInfo.isGitRepo) {
+    return null;
+  }
+
+  const { branch, modified, staged, untracked, ahead, behind } = gitInfo;
+
+  const hasChanges = modified > 0 || staged > 0 || untracked;
+  const hasSyncStatus = ahead > 0 || behind > 0;
+
+  return (
+    <div className={styles.container}>
+      {/* Branch name with icon */}
+      <div className={styles.branch}>
+        <BranchIcon />
+        <span className={styles.branchName} title={branch}>
+          {branch}
+        </span>
+      </div>
+
+      {/* Status indicators */}
+      {hasChanges && (
+        <>
+          <span className={styles.separator} />
+          <div className={styles.status}>
+            {/* Modified files */}
+            {modified > 0 && (
+              <span className={`${styles.indicator} ${styles.modified}`} title={`${modified} modified`}>
+                {modified > 9 ? <span className={styles.modifiedDot} /> : modified}
+              </span>
+            )}
+
+            {/* Staged files */}
+            {staged > 0 && (
+              <span className={`${styles.indicator} ${styles.staged}`} title={`${staged} staged`}>
+                {staged > 9 ? <span className={styles.stagedDot} /> : staged}
+              </span>
+            )}
+
+            {/* Untracked indicator */}
+            {untracked && (
+              <span className={styles.untracked} title="Untracked files">
+                ?
+              </span>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Ahead/behind badges */}
+      {hasSyncStatus && (
+        <>
+          <span className={styles.separator} />
+          <div className={styles.syncStatus}>
+            {ahead > 0 && (
+              <span className={`${styles.badge} ${styles.ahead}`} title={`${ahead} commit(s) ahead`}>
+                ↑{ahead}
+              </span>
+            )}
+            {behind > 0 && (
+              <span className={`${styles.badge} ${styles.behind}`} title={`${behind} commit(s) behind`}>
+                ↓{behind}
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default memo(GitStatus);

--- a/lib/components/Header/GitStatus/styles.module.css
+++ b/lib/components/Header/GitStatus/styles.module.css
@@ -1,0 +1,108 @@
+/* GitStatus Component Styles */
+
+.container {
+  height: 100%;
+  padding: 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--theme-disabled);
+  white-space: nowrap;
+}
+
+/* Branch section */
+.branch {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--theme-foreground);
+}
+
+.branchIcon {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+}
+
+.branchName {
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Status indicators */
+.status {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+}
+
+/* Modified files - yellow */
+.modified {
+  color: #e2b93d;
+}
+
+.modifiedDot {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 50%;
+  background-color: #e2b93d;
+}
+
+/* Staged files - green */
+.staged {
+  color: #73c991;
+}
+
+.stagedDot {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 50%;
+  background-color: #73c991;
+}
+
+/* Untracked - orange */
+.untracked {
+  color: #ce9178;
+  font-weight: 600;
+}
+
+/* Ahead/behind badges */
+.syncStatus {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.badge {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.0625rem 0.25rem;
+  border-radius: 0.1875rem;
+  font-size: 0.6875rem;
+  background-color: var(--theme-background-alt, rgba(255, 255, 255, 0.1));
+}
+
+.ahead {
+  color: #73c991;
+}
+
+.behind {
+  color: #f14c4c;
+}
+
+/* Separator */
+.separator {
+  width: 1px;
+  height: 0.75rem;
+  background-color: var(--theme-disabled);
+  opacity: 0.4;
+}

--- a/lib/components/Header/index.tsx
+++ b/lib/components/Header/index.tsx
@@ -5,6 +5,7 @@ import { BrowserWindow } from '@electron/remote';
 import { execCommand } from 'app/keymaps/commands';
 import { removeThemeVariables, setThemeVariables } from 'app/common/themes';
 import useStore from 'lib/store';
+import { useGitStatus } from 'lib/hooks/useGitStatus';
 
 import {
   CloseIcon,
@@ -17,15 +18,17 @@ import {
 } from 'lib/components/Icons';
 import TabGroup from './Tab';
 import Popover from './Popover';
+import GitStatus from './GitStatus';
 import styles from './styles.module.css';
 
 const Header: React.FC<{ welcome?: boolean }> = ({ welcome }) => {
   const {
-    current: { origin },
+    current: { origin, focused },
     options: { theme, preserveBackground, acrylic },
   } = useStore();
 
   const [isMaximized, setMaximized] = useState<boolean>(false);
+  const gitInfo = useGitStatus(focused || null);
 
   const handleAction = (action: string) => {
     const focusedWindow = BrowserWindow.getFocusedWindow()!;
@@ -85,10 +88,13 @@ const Header: React.FC<{ welcome?: boolean }> = ({ welcome }) => {
       <div className={styles.dragRegion} />
       <div className={styles.actions}>
         {!welcome && (
-          <div className={styles.actionItem} onClick={() => execCommand('app:settings')}>
-            <SettingsIcon />
-            <Popover label="Settings" />
-          </div>
+          <Fragment>
+            <GitStatus gitInfo={gitInfo} />
+            <div className={styles.actionItem} onClick={() => execCommand('app:settings')}>
+              <SettingsIcon />
+              <Popover label="Settings" />
+            </div>
+          </Fragment>
         )}
         <div className={styles.actionItem} onClick={() => handleAction('minimize')}>
           <MinimizeIcon />

--- a/lib/hooks/useGitStatus.ts
+++ b/lib/hooks/useGitStatus.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'preact/hooks';
+import ipc from 'shared/ipc/renderer';
+
+interface GitInfo {
+  branch: string;
+  modified: number;
+  staged: number;
+  untracked: boolean;
+  ahead: number;
+  behind: number;
+  isGitRepo: boolean;
+}
+
+export function useGitStatus(instanceId: string | null): GitInfo | null {
+  const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
+
+  useEffect(() => {
+    if (!instanceId) {
+      setGitInfo(null);
+      return;
+    }
+
+    const handleGitInfo = (data: { id: string; gitInfo: GitInfo | null }) => {
+      if (data.id === instanceId) {
+        setGitInfo(data.gitInfo);
+      }
+    };
+
+    ipc.on('git:info', handleGitInfo);
+
+    ipc.send('git:get-info', { id: instanceId });
+
+    const intervalId = setInterval(() => {
+      ipc.send('git:get-info', { id: instanceId });
+    }, 1500);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [instanceId]);
+
+  return gitInfo;
+}
+
+export default useGitStatus;


### PR DESCRIPTION
Display git repository status in the title bar next to settings button:
- Branch name with icon
- Modified files count (yellow)
- Staged files count (green)
- Untracked files indicator (orange ?)
- Ahead/behind remote indicators (↑/↓)

Implementation:
- app/services/git.ts: Git service to fetch repo info (branch, status, ahead/behind)
- lib/hooks/useGitStatus.ts: React hook with IPC communication and 1.5s polling
- lib/components/Header/GitStatus/: Display component with CSS modules
- app/events.ts: IPC handler to get CWD from PTY and fetch git info

The status updates automatically when changing directories (cd) into/out of git repos.