### PR TITLE
feat: add snippet manager for saving favorite commands

### DIFF
--- a/app/keymaps/default.yaml
+++ b/app/keymaps/default.yaml
@@ -56,6 +56,8 @@ terminal:paste:
   - ctrl+shift+v
 terminal:search:
   - ctrl+shift+f
+terminal:snippets:
+  - ctrl+shift+;
 terminal:select-all:
   - ctrl+shift+a
 window:create:

--- a/app/keymaps/schema.ts
+++ b/app/keymaps/schema.ts
@@ -10,6 +10,7 @@ export const schema: Record<string, string> = {
   'terminal:clear': 'Clear terminal',
   'terminal:search': 'Search',
   'terminal:history': 'History',
+  'terminal:snippets': 'Snippets',
   'terminal:copy': 'Copy',
   'terminal:paste': 'Paste',
   'terminal:select-all': 'Select all',
@@ -46,7 +47,7 @@ export const boundCommands: Record<string, Record<string, any>> = {
   },
   terminal: {
     action: ['copy', 'paste', 'select-all', 'clear', 'focus', 'connected'],
-    modal: ['search', 'history'],
+    modal: ['search', 'history', 'snippets'],
   },
   pane: {
     action: ['expand', 'collapse', 'broadcast'],

--- a/lib/components/Modal/Commands/schema.ts
+++ b/lib/components/Modal/Commands/schema.ts
@@ -13,6 +13,7 @@ const instanceSchema = {
     'terminal:clear',
     'terminal:search',
     'terminal:history',
+    'terminal:snippets',
     'terminal:copy',
     'terminal:paste',
     'terminal:select-all',

--- a/lib/components/Modal/Snippets/index.tsx
+++ b/lib/components/Modal/Snippets/index.tsx
@@ -1,0 +1,192 @@
+import { Fragment } from 'preact';
+import { memo, useEffect, useRef, useState } from 'preact/compat';
+import { useTranslation } from 'react-i18next';
+
+import storage from 'app/utils/local-storage';
+import { useKeyboardIndex } from 'lib/utils/hooks';
+
+import styles from '../styles.module.css';
+import {
+  Actions,
+  ActionBtn,
+  Button,
+  Command,
+  Form,
+  FormActions,
+  Input,
+  Item,
+  List,
+  Name,
+  SnippetInfo,
+  Warning,
+  Wrapper,
+} from './styles';
+
+interface ISnippet {
+  id: string;
+  name: string;
+  command: string;
+  createdAt: string;
+}
+
+const Snippets: React.FC<ModalProps> = ({ store, isVisible, handleModal }) => {
+  const [snippets, setSnippets] = useState<ISnippet[]>(() => {
+    const stored = storage.parseItem('snippets');
+    return Array.isArray(stored) ? stored : [];
+  });
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newCommand, setNewCommand] = useState('');
+
+  const [selectedIndex, setSelectedIndex] = useKeyboardIndex(snippets.length);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+
+  const { t } = useTranslation();
+
+  const handleAdd = () => {
+    if (!newName.trim() || !newCommand.trim()) return;
+
+    const snippet: ISnippet = {
+      id: Date.now().toString(),
+      name: newName.trim(),
+      command: newCommand.trim(),
+      createdAt: new Date().toISOString(),
+    };
+
+    const updated = [snippet, ...snippets];
+    setSnippets(updated);
+    storage.updateItem('snippets', updated);
+
+    setNewName('');
+    setNewCommand('');
+    setIsAdding(false);
+  };
+
+  const handleDelete = (id: string) => {
+    const updated = snippets.filter(s => s.id !== id);
+    setSnippets(updated);
+    storage.updateItem('snippets', updated);
+  };
+
+  const handleRun = (command: string) => {
+    store.onData(command);
+    handleModal();
+  };
+
+  const handleCancel = () => {
+    setIsAdding(false);
+    setNewName('');
+    setNewCommand('');
+  };
+
+  useEffect(() => {
+    if (isAdding && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isAdding]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && selectedIndex !== -1 && !isAdding) {
+        handleRun(snippets[selectedIndex].command);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selectedIndex, snippets, isAdding]);
+
+  useEffect(() => {
+    const element = listRef.current?.children[selectedIndex] as HTMLElement;
+    if (element) {
+      element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [selectedIndex]);
+
+  return (
+    <div
+      className={`${styles.container} ${isVisible ? styles.containerVisible : styles.containerHidden}`}
+      style={{ maxWidth: '22rem' }}
+    >
+      <div className={styles.tags}>
+        <div className={`${styles.tag} ${styles.tagTitle}`}>
+          {t('Snippets')}
+        </div>
+        {!isAdding && (
+          <div className={styles.tag} onClick={() => setIsAdding(true)}>
+            + {t('Add')}
+          </div>
+        )}
+      </div>
+      <div className={styles.content}>
+        <Wrapper>
+          {isAdding && (
+            <Form>
+              <Input
+                ref={inputRef}
+                placeholder={t('Snippet name')}
+                value={newName}
+                onChange={e => setNewName((e.target as HTMLInputElement).value)}
+                onKeyDown={e => e.key === 'Escape' && handleCancel()}
+              />
+              <Input
+                placeholder={t('Command')}
+                value={newCommand}
+                onChange={e => setNewCommand((e.target as HTMLInputElement).value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') handleAdd();
+                  if (e.key === 'Escape') handleCancel();
+                }}
+              />
+              <FormActions>
+                <Button onClick={handleCancel}>{t('Cancel')}</Button>
+                <Button
+                  $primary
+                  disabled={!newName.trim() || !newCommand.trim()}
+                  onClick={handleAdd}
+                >
+                  {t('Save')}
+                </Button>
+              </FormActions>
+            </Form>
+          )}
+
+          {snippets.length > 0 ? (
+            <List ref={listRef}>
+              {snippets.map((snippet, index) => (
+                <Item
+                  key={snippet.id}
+                  $selected={selectedIndex === index}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  onClick={() => handleRun(snippet.command)}
+                >
+                  <SnippetInfo>
+                    <Name>{snippet.name}</Name>
+                    <Command>{snippet.command}</Command>
+                  </SnippetInfo>
+                  <Actions>
+                    <ActionBtn
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleDelete(snippet.id);
+                      }}
+                    >
+                      {t('Delete')}
+                    </ActionBtn>
+                  </Actions>
+                </Item>
+              ))}
+            </List>
+          ) : (
+            !isAdding && <Warning>{t('No snippets yet')}</Warning>
+          )}
+        </Wrapper>
+      </div>
+    </div>
+  );
+};
+
+export default memo(Snippets);

--- a/lib/components/Modal/Snippets/styles.ts
+++ b/lib/components/Modal/Snippets/styles.ts
@@ -1,0 +1,184 @@
+import styled, { css } from 'styled-components';
+
+export const Wrapper = styled.div`
+  padding: 0.875rem 1rem;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Actions = styled.div`
+  margin-left: auto;
+  gap: 0.375rem;
+  opacity: 0;
+  display: flex;
+  align-items: center;
+  transition: opacity 0.2s ease 0s;
+`;
+
+export const ActionBtn = styled.span`
+  cursor: pointer;
+  font-size: 0.6875rem;
+  padding: 0.25rem 0.5rem;
+  color: ${props => props.theme.disabled};
+  border: 1px solid ${props => props.theme.border};
+  border-radius: 3px;
+  transition: all 0.2s ease 0s;
+
+  &:hover {
+    color: ${props => props.theme.foreground};
+    border-color: ${props => props.theme.icon};
+  }
+`;
+
+export const SnippetInfo = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+export const Name = styled.div`
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: ${props => props.theme.foreground};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+export const Command = styled.div`
+  font-size: 0.6875rem;
+  color: ${props => props.theme.disabled};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+export const Icon = styled.div`
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: ${props => props.theme.icon};
+  background: ${props => props.theme.divider};
+  border-radius: 6px;
+  transition: all 0.2s ease 0s;
+`;
+
+const selectedCss = css`
+  background: ${props => props.theme.divider};
+
+  ${Actions} {
+    opacity: 1;
+  }
+
+  ${Icon} {
+    color: ${props => props.theme.background};
+    background: ${props => props.theme.foreground};
+  }
+`;
+
+export const Warning = styled.span`
+  padding: 1rem 0;
+  font-size: 0.8125rem;
+  text-align: center;
+  color: ${props => props.theme.disabled};
+`;
+
+export const List = styled.ul`
+  max-height: 14rem;
+  gap: 0.25rem;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  list-style-type: none;
+
+  &::-webkit-scrollbar {
+    width: 0.25rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${props => props.theme.scrollbar};
+    border-radius: 4px;
+  }
+`;
+
+export const Item = styled.li<{ $selected: boolean }>`
+  padding: 0.625rem 0.75rem;
+  gap: 0.75rem;
+  display: flex;
+  align-items: center;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s ease 0s;
+
+  ${({ $selected }) => $selected && selectedCss}
+`;
+
+export const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  margin-bottom: 0.875rem;
+  padding-bottom: 0.875rem;
+  border-bottom: 1px solid ${props => props.theme.border};
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  color: ${props => props.theme.foreground};
+  background: transparent;
+  border: 1px solid ${props => props.theme.border};
+  border-radius: 6px;
+  outline: none;
+  transition: border-color 0.2s ease 0s;
+
+  &:focus {
+    border-color: ${props => props.theme.icon};
+  }
+
+  &::placeholder {
+    color: ${props => props.theme.disabled};
+  }
+`;
+
+export const FormActions = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
+`;
+
+export const Button = styled.button<{ $primary?: boolean }>`
+  height: 2rem;
+  padding: 0 1rem;
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  color: ${props => (props.$primary ? props.theme.background : props.theme.foreground)};
+  background: ${props => (props.$primary ? props.theme.foreground : 'transparent')};
+  border: 1px solid ${props => (props.$primary ? 'transparent' : props.theme.border)};
+  border-radius: 6px;
+  transition: all 0.2s ease 0s;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+`;

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -19,6 +19,7 @@ import Sync from './Sync';
 import Workspace from './Workspace';
 import History from './History';
 import Keymaps from './Keymaps';
+import Snippets from './Snippets';
 
 const components = {
   Search,
@@ -36,6 +37,7 @@ const components = {
     Workspace,
     History,
     Keymaps,
+    Snippets,
   },
 };
 

--- a/locales/de-DE.po
+++ b/locales/de-DE.po
@@ -1125,3 +1125,27 @@ msgstr "Versuchen Sie eine andere Suche"
 msgid "Search for a command"
 msgstr "Nach einem Befehl suchen"
 
+
+msgid "Snippets"
+msgstr "Snippets"
+
+msgid "Add"
+msgstr "Hinzufügen"
+
+msgid "Snippet name"
+msgstr "Snippet-Name"
+
+msgid "Command"
+msgstr "Befehl"
+
+msgid "Cancel"
+msgstr "Abbrechen"
+
+msgid "Save"
+msgstr "Speichern"
+
+msgid "Delete"
+msgstr "Löschen"
+
+msgid "No snippets yet"
+msgstr "Noch keine Snippets"

--- a/locales/es-ES.po
+++ b/locales/es-ES.po
@@ -1125,3 +1125,27 @@ msgstr "Prueba una búsqueda diferente"
 msgid "Search for a command"
 msgstr "Buscar un comando"
 
+
+msgid "Snippets"
+msgstr "Snippets"
+
+msgid "Add"
+msgstr "Agregar"
+
+msgid "Snippet name"
+msgstr "Nombre del snippet"
+
+msgid "Command"
+msgstr "Comando"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Save"
+msgstr "Guardar"
+
+msgid "Delete"
+msgstr "Eliminar"
+
+msgid "No snippets yet"
+msgstr "No hay snippets todavía"

--- a/locales/fr-FR.po
+++ b/locales/fr-FR.po
@@ -1125,3 +1125,27 @@ msgstr "Essayez une autre recherche"
 msgid "Search for a command"
 msgstr "Rechercher une commande"
 
+
+msgid "Snippets"
+msgstr "Snippets"
+
+msgid "Add"
+msgstr "Ajouter"
+
+msgid "Snippet name"
+msgstr "Nom du snippet"
+
+msgid "Command"
+msgstr "Commande"
+
+msgid "Cancel"
+msgstr "Annuler"
+
+msgid "Save"
+msgstr "Enregistrer"
+
+msgid "Delete"
+msgstr "Supprimer"
+
+msgid "No snippets yet"
+msgstr "Aucun snippet pour le moment"

--- a/locales/pt-BR.po
+++ b/locales/pt-BR.po
@@ -1125,3 +1125,27 @@ msgstr "Tente uma busca diferente"
 msgid "Search for a command"
 msgstr "Buscar um comando"
 
+
+msgid "Snippets"
+msgstr "Snippets"
+
+msgid "Add"
+msgstr "Adicionar"
+
+msgid "Snippet name"
+msgstr "Nome do snippet"
+
+msgid "Command"
+msgstr "Comando"
+
+msgid "Cancel"
+msgstr "Cancelar"
+
+msgid "Save"
+msgstr "Salvar"
+
+msgid "Delete"
+msgstr "Excluir"
+
+msgid "No snippets yet"
+msgstr "Nenhum snippet ainda"


### PR DESCRIPTION
Add a snippet manager that allows users to save, organize and quickly insert frequently used commands.                          
- Add snippet creation, editing and deletion
- Store snippets in local storage for persistence
- Integrate snippet insertion into the terminal workflow